### PR TITLE
JRE Alpine + JVM Options

### DIFF
--- a/sources/modules/api-manager/docker/Dockerfile
+++ b/sources/modules/api-manager/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 
 # Metadata
 LABEL module.maintainer="onesaitplatform@indra.es" \
@@ -32,7 +32,7 @@ EXPOSE 19100
 
 #HZ_SERVICE_DISCOVERY_STRATEGY can take values: service or zookeeper
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" \
     SERVER_NAME=localhost \
     REALTIMEDBSERVERS=realtimedb:27017 \
     CONFIGDBSERVERS=configdb:3306 \

--- a/sources/modules/cache-server/docker/Dockerfile
+++ b/sources/modules/cache-server/docker/Dockerfile
@@ -32,7 +32,7 @@ EXPOSE 20001 5701
 
 #HZ_SERVICE_DISCOVERY_STRATEGY can take values: service or zookeeper
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" \
     SERVER_NAME=localhost \
     HZ_SERVICE_DISCOVERY_STRATEGY=service \
     HZ_ZOOKEEPER_URL=zookeeper:2181

--- a/sources/modules/config-init/docker/Dockerfile
+++ b/sources/modules/config-init/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 
 # Metadata
 LABEL module.maintainer="onesaitplatform@indra.es" \
@@ -35,7 +35,7 @@ EXPOSE 21000
 
 #HZ_SERVICE_DISCOVERY_STRATEGY can take values: service or zookeeper
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" \
     SERVER_NAME=localhost \
     REALTIMEDBSERVERS=realtimedb:27017 \
     REALTIMEDBAUTHDB=admin \

--- a/sources/modules/control-panel/docker/Dockerfile
+++ b/sources/modules/control-panel/docker/Dockerfile
@@ -71,7 +71,7 @@ EXPOSE 18000 5701
 
 #HZ_SERVICE_DISCOVERY_STRATEGY can take values: service or zookeeper
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -javaagent:/usr/local/aspectjweaver-$ASPECTJ_VERSION.jar" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -javaagent:/usr/local/aspectjweaver-$ASPECTJ_VERSION.jar" \
     SERVER_NAME=localhost \
     KAFKAENABLED=false \
     KAFKAHOST=kafka \

--- a/sources/modules/dashboard-engine/docker/Dockerfile
+++ b/sources/modules/dashboard-engine/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 
 # Metadata
 LABEL module.maintainer="onesaitplatform" \
@@ -32,7 +32,7 @@ EXPOSE 18300
 
 #HZ_SERVICE_DISCOVERY_STRATEGY can take values: service or zookeeper
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" \
     SERVER_NAME=localhost \
     REALTIMEDBSERVERS=realtimedb:27017 \
     REALTIMEDBAUTHDB=admin \

--- a/sources/modules/device-simulator/docker/Dockerfile
+++ b/sources/modules/device-simulator/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 
 # Metadata
 LABEL module.maintainer="onesaitplatform@indra.es" \
@@ -32,7 +32,7 @@ EXPOSE 19200
 
 #HZ_SERVICE_DISCOVERY_STRATEGY can take values: service or zookeeper
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" \
     SERVER_NAME=localhost \
     REALTIMEDBSERVERS=realtimedb:27017 \
     CONFIGDBSERVERS=configdb:3306 \

--- a/sources/modules/digitaltwin-broker/docker/Dockerfile
+++ b/sources/modules/digitaltwin-broker/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 
 # Metadata
 LABEL module.maintainer="onesaitplatform@indra.es" \
@@ -32,7 +32,7 @@ EXPOSE 19300
 
 #HZ_SERVICE_DISCOVERY_STRATEGY can take values: service or zookeeper 
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" \
     SERVER_NAME=localhost \
     REALTIMEDBSERVERS=realtimedb:27017 \
     REALTIMEDBAUTHDB=admin \

--- a/sources/modules/flow-engine/docker/Dockerfile
+++ b/sources/modules/flow-engine/docker/Dockerfile
@@ -12,7 +12,7 @@ LABEL module.maintainer="onesaitplatform@indra.es" \
 
 ENV ASPECTJ_VERSION 1.8.9
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx2G -javaagent:/usr/local/aspectjweaver-$ASPECTJ_VERSION.jar" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -javaagent:/usr/local/aspectjweaver-$ASPECTJ_VERSION.jar" \
 	SERVERNAME=localhost \
     REALTIMEDBSERVERS=realtimedb:27017 \
     CONFIGDBSERVERS=configdb:3306 \

--- a/sources/modules/iot-broker/docker/Dockerfile
+++ b/sources/modules/iot-broker/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 
 # metadata
 LABEL module.maintainer="onesaitplatform@indra.es" \
@@ -32,7 +32,7 @@ EXPOSE 19000 1883 8883
 
 #HZ_SERVICE_DISCOVERY_STRATEGY can take values: service or zookeeper
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms2G -Xmx2G" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms2G -Xmx2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" \
     SERVER_NAME=localhost \
     KAFKAENABLED=false \
     KAFKAHOST=kafka \

--- a/sources/modules/monitoring-ui/docker/Dockerfile
+++ b/sources/modules/monitoring-ui/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 
 # Metadata
 LABEL module.maintainer="onesaitplatform@indra.es" \
@@ -34,7 +34,7 @@ VOLUME ["/tmp", "/var/log/platform-logs"]
 
 EXPOSE 18100
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" \
     SERVER_NAME=localhost \
     CONFIGDBSERVERS=configdb:3306 \
     JDBCPROTOCOL="jdbc:mysql:" \

--- a/sources/modules/oauth-server/docker/Dockerfile
+++ b/sources/modules/oauth-server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 
 # Metadata
 LABEL module.maintainer="onesaitplatform@indra.es" \
@@ -40,5 +40,7 @@ VOLUME ["/tmp", "/var/log/platform-logs"]
 USER onesait
 
 EXPOSE 21000
+
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
 
 ENTRYPOINT java $JAVA_OPTS -Dspring.application.json=$ONESAIT_PROPERTIES -Djava.security.egd=file:/dev/./urandom -Dspring.profiles.active=docker -jar /app.jar

--- a/sources/modules/rtdb-maintainer/docker/Dockerfile
+++ b/sources/modules/rtdb-maintainer/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 
 # Metadata
 LABEL module.maintainer="onesaitplatform@indra.es" \
@@ -61,5 +61,7 @@ RUN chown -R onesait:onesait /var/log/platform-logs && \
 VOLUME ["/tmp", "/var/log/platform-logs", "/usr/local/files"]
     
 USER onesait
+
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
 
 ENTRYPOINT java $JAVA_OPTS -Dspring.application.json=$ONESAIT_PROPERTIES -Djava.security.egd=file:/dev/./urandom -Dspring.profiles.active=docker -jar /app.jar

--- a/sources/modules/rules-engine/docker/Dockerfile
+++ b/sources/modules/rules-engine/docker/Dockerfile
@@ -36,7 +36,7 @@ EXPOSE 20200
 
 #HZ_SERVICE_DISCOVERY_STRATEGY can take values: service or zookeeper
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" \
     SERVER_NAME=localhost \
     JDBCPROTOCOL="jdbc:mysql:" \
     CONFIGDBSERVERS=configdb:3306 \

--- a/sources/modules/scripting-engine/docker/Dockerfile
+++ b/sources/modules/scripting-engine/docker/Dockerfile
@@ -1,6 +1,8 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 
-LABEL maintainer "plataformasofia2@indra.es"
+# metadata
+LABEL module.maintainer="onesaitplatform@indra.es" \
+	  module.name="scripting-engine"	
 
 VOLUME /tmp
 
@@ -9,5 +11,7 @@ ARG JAR_FILE
 ADD *-exec.jar app.jar
 
 EXPOSE 8080
+
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
 
 ENTRYPOINT java $JAVA_OPTS -Dspring.application.json=$ONESAIT_PROPERTIES -Djava.security.egd=file:/dev/./urandom -Dspring.profiles.active=docker -jar /app.jar

--- a/sources/modules/semantic-inf-broker/docker/Dockerfile
+++ b/sources/modules/semantic-inf-broker/docker/Dockerfile
@@ -32,7 +32,7 @@ EXPOSE 20000
 
 #HZ_SERVICE_DISCOVERY_STRATEGY can take values: service or zookeeper
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" \
     SERVER_NAME=localhost \
     KAFKAENABLED=false \
     KAFKAHOST=kafka \

--- a/sources/modules/video-broker/docker/Dockerfile
+++ b/sources/modules/video-broker/docker/Dockerfile
@@ -92,7 +92,7 @@ EXPOSE 24000
 
 #HZ_SERVICE_DISCOVERY_STRATEGY can take values: service or zookeeper
 
-ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G" \
+ENV JAVA_OPTS="$JAVA_OPTS -Xms1G -Xmx3G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap" \
     SERVER_NAME=localhost \
     KAFKAENABLED=false \
     KAFKAHOST=kafka \


### PR DESCRIPTION
- Changing JDK to JRE.
- Adding -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap JVM Options due to memory issues using Java 8 inside docker containers.